### PR TITLE
docs: Update README for threads and piggyback detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,49 @@ GitHub-Discord integration bot that tracks PRs, CI, issues, and releases with th
 
 ## Features
 
-- **PR Notifications** - Creates a Discord message per PR, updates as replies
-- **CI Status** - Shows workflow status (running, passed, failed)
-- **Review Tracking** - Detects Copilot and agent-review comments
+- **PR Notifications** - Creates a Discord embed per PR with a thread for updates
+- **Threaded Updates** - All updates (pushes, CI, reviews, merge) go to the PR's thread
+- **CI Status** - Shows workflow status (pending, running, passed, failed)
+- **Review Detection** - Detects Copilot and agent-review via piggyback on push/CI events
 - **Issue & Release Notifications** - Separate channels for different event types
 - **Persistent State** - SQLite tracks PR ↔ message mappings
+- **Stale Message Handling** - Gracefully recovers if Discord messages are deleted
+
+## How It Works
+
+### Message Flow
+
+When a PR is opened, repo-relay creates an embed with a thread attached:
+
+```
+┌─────────────────────────────────────────────┐
+│ 🔀 PR #123: Add combat animations           │
+│                                             │
+│ Author: @username                           │
+│ Branch: feat/combat-animations → main       │
+│ Changes: 12 files (+450, -120)              │
+│                                             │
+│ 📋 Reviews                                  │
+│ • Copilot: ⏳ Pending                       │
+│ • Agent Review: ⏳ Pending                  │
+│                                             │
+│ 🔄 CI: ⏳ Pending                           │
+└─────────────────────────────────────────────┘
+   └── Thread: "PR #123: Add combat animations"
+       ├── 📋 Updates for PR #123 will appear here.
+       ├── 📤 Push: 1 commit by @username
+       ├── 🔄 CI: ✅ Passed (CI)
+       ├── 🤖 Copilot: Reviewed
+       └── 🎉 Merged by @username
+```
+
+### Review Detection (Piggyback Approach)
+
+GitHub Apps using `GITHUB_TOKEN` don't trigger workflows. To work around this:
+
+- When any PR event fires (push, CI completion), the bot checks GitHub API for reviews
+- If Copilot or agent-review is detected, the embed and thread are updated
+- Reviews are detected on the **next** event, not immediately
 
 ## Quick Start
 
@@ -16,8 +54,10 @@ GitHub-Discord integration bot that tracks PRs, CI, issues, and releases with th
 
 1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
 2. Create new application → Bot → Reset Token → Copy token
-3. Enable these intents: "Message Content Intent"
-4. Generate invite URL with permissions: `Send Messages`, `Embed Links`, `Read Message History`
+3. Enable intents: **Message Content Intent**, **Server Members Intent**
+4. Generate invite URL (OAuth2 → URL Generator):
+   - Scopes: `bot`
+   - Permissions: `Send Messages`, `Create Public Threads`, `Send Messages in Threads`, `Embed Links`, `Read Message History`
 5. Invite bot to your server
 
 ### 2. Get Channel IDs
@@ -29,29 +69,29 @@ GitHub-Discord integration bot that tracks PRs, CI, issues, and releases with th
 
 Add these secrets to your GitHub repository (Settings → Secrets and variables → Actions):
 
-| Secret | Description |
-|--------|-------------|
-| `DISCORD_BOT_TOKEN` | Bot token from step 1 |
-| `DISCORD_CHANNEL_PRS` | Channel ID for PR notifications |
-| `DISCORD_CHANNEL_ISSUES` | Channel ID for issue notifications |
-| `DISCORD_CHANNEL_RELEASES` | Channel ID for release notifications |
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token from step 1 |
+| `DISCORD_CHANNEL_PRS` | Yes | Channel ID for PR notifications |
+| `DISCORD_CHANNEL_ISSUES` | No | Channel ID for issue notifications |
+| `DISCORD_CHANNEL_RELEASES` | No | Channel ID for release notifications |
 
 ### 4. Add Workflow
 
-Create `.github/workflows/discord-notifications.yml`:
+Create `.github/workflows/discord-bot.yml`:
 
 ```yaml
-name: Discord Notifications
+name: Discord Bot Notifications
 
 on:
   pull_request:
-    types: [opened, synchronize, closed, reopened]
+    types: [opened, synchronize, closed, reopened, edited, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted]
   issue_comment:
     types: [created]
   issues:
-    types: [opened, closed, labeled]
+    types: [opened, closed]
   release:
     types: [published]
   workflow_run:
@@ -60,52 +100,64 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest  # or self-hosted for persistent state
+    # Self-hosted recommended for persistent state
+    runs-on: self-hosted  # or ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: read
+      contents: read
+      statuses: read
+    # Skip workflow_run events without associated PRs
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.pull_requests[0] != null
+
     steps:
-      - name: Discord Notification
-        uses: blamechris/repo-relay@v1
+      - name: Checkout repo-relay
+        uses: actions/checkout@v4
         with:
-          discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
-          channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}
-          channel_issues: ${{ secrets.DISCORD_CHANNEL_ISSUES }}
-          channel_releases: ${{ secrets.DISCORD_CHANNEL_RELEASES }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-```
+          repository: blamechris/repo-relay
+          ref: v1.0.0
+          path: .repo-relay
 
-## Message Flow
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: .repo-relay/package-lock.json
 
-### PR Opened
+      - name: Install dependencies
+        working-directory: .repo-relay
+        run: npm ci --omit=dev
 
-```
-┌─────────────────────────────────────────────┐
-│ 🔀 PR #123: Add combat animations           │
-│                                             │
-│ Author: @username                           │
-│ Branch: feat/combat-animations              │
-│ Files: 12 changed (+450, -120)              │
-│                                             │
-│ 📋 Reviews: ⏳ Pending                      │
-│ 🔄 CI: ⏳ Running...                        │
-└─────────────────────────────────────────────┘
-```
+      - name: Run repo-relay
+        working-directory: .repo-relay
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_CHANNEL_PRS: ${{ secrets.DISCORD_CHANNEL_PRS }}
+          DISCORD_CHANNEL_ISSUES: ${{ secrets.DISCORD_CHANNEL_ISSUES }}
+          DISCORD_CHANNEL_RELEASES: ${{ secrets.DISCORD_CHANNEL_RELEASES }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STATE_DIR: ~/.repo-relay
+        run: node dist/cli.js
 
-### Updates (as replies)
-
-```
-↳ 📤 Push: 2 commits (abc1234)
-↳ ✅ CI passed
-↳ 🤖 Copilot reviewed: 3 comments
-↳ 🔍 Agent review: Approved
-↳ 🎉 Merged to main!
+      - name: Cleanup
+        if: always()
+        run: rm -rf .repo-relay
 ```
 
 ## State Storage
 
-**Self-hosted runners (recommended):**
-State persists in `~/.repo-relay/{repo-name}/state.db`
+| Runner Type | Storage Location | Persistence |
+|-------------|------------------|-------------|
+| **Self-hosted** (recommended) | `~/.repo-relay/{repo-name}/state.db` | Permanent |
+| **GitHub-hosted** | Workflow artifacts | Per-run (requires artifact upload/download) |
 
-**GitHub-hosted runners:**
-State is stored as artifacts (slower, but works)
+For GitHub-hosted runners, you'll need to add artifact upload/download steps to persist state between runs.
 
 ## Configuration
 
@@ -115,7 +167,27 @@ State is stored as artifacts (slower, but works)
 | `DISCORD_CHANNEL_PRS` | Yes | Channel for PR notifications |
 | `DISCORD_CHANNEL_ISSUES` | No | Channel for issue notifications |
 | `DISCORD_CHANNEL_RELEASES` | No | Channel for release notifications |
+| `GITHUB_TOKEN` | Yes | GitHub token for API access (review detection) |
 | `STATE_DIR` | No | Directory for SQLite state (default: `~/.repo-relay`) |
+
+## Known Limitations
+
+1. **Review events don't trigger immediately** - GitHub Apps using `GITHUB_TOKEN` don't trigger workflows. Reviews are detected on the next push or CI event via the piggyback approach.
+
+2. **Self-hosted runners recommended** - GitHub-hosted runners don't persist state between runs without additional artifact handling.
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build TypeScript
+npm run build
+
+# Run locally (requires environment variables)
+npm run dev
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
Update README to reflect recent changes:

- **Threaded updates** - Updates now go to Discord threads, not replies
- **Piggyback review detection** - Explain how reviews are detected on next event
- **Updated workflow example** - Full configuration matching actual usage
- **Known limitations** - Document GITHUB_TOKEN limitation for reviews
- **Discord permissions** - Add thread-related permissions to setup