### PR TITLE
fix(action): Remove npm caching, add input validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,13 +34,28 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: ${{ github.action_path }}/package-lock.json
 
     - name: Install dependencies
       shell: bash
       working-directory: ${{ github.action_path }}
-      run: npm ci --omit=dev
+      run: npm ci --omit=dev 2>/dev/null || npm ci --production
+
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.discord_bot_token }}" ]; then
+          echo "::error::discord_bot_token is required but was not provided"
+          exit 1
+        fi
+        if [ -z "${{ inputs.channel_prs }}" ]; then
+          echo "::error::channel_prs is required but was not provided"
+          exit 1
+        fi
+        if ! [[ "${{ inputs.channel_prs }}" =~ ^[0-9]+$ ]]; then
+          echo "::error::channel_prs must be a numeric Discord channel ID, got: ${{ inputs.channel_prs }}"
+          exit 1
+        fi
+        echo "Inputs validated successfully"
 
     - name: Run repo-relay
       shell: bash


### PR DESCRIPTION
## Summary

Fixes first-run failure on self-hosted runners caused by npm caching issues.

Fixes blamechris/archery-apprentice#497

## Problem

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

The `cache-dependency-path: ${{ github.action_path }}/package-lock.json` doesn't resolve correctly on self-hosted runners, causing the action to fail on the very first PR - a bad first impression.

## Solution

1. **Remove npm caching** - Simplest, most reliable fix. The speed difference is negligible for a small package.

2. **Add npm ci fallback** - `npm ci --omit=dev || npm ci --production` handles both modern and older npm versions.

3. **Add input validation** - Clear error messages instead of cryptic stack traces:
   - `discord_bot_token is required but was not provided`
   - `channel_prs is required but was not provided`
   - `channel_prs must be a numeric Discord channel ID`

## Before/After

**Before:** Red X on first PR, confusing cache error
**After:** Works on first run, clear errors if misconfigured

## Test Plan

- [ ] Re-run archery-apprentice PR #497 after updating v1 tag
- [ ] Verify works on GitHub-hosted runners
- [ ] Verify works on self-hosted runners
- [ ] Test with missing discord_bot_token (should show clear error)
- [ ] Test with invalid channel_prs (should show clear error)