### PR TITLE
chore: Add merge-gate pattern to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,18 @@ After merging, update the issue with:
 
 **NEVER commit directly to main.** Always use feature branches and PRs.
 
+### Merge Gate — MANDATORY short-circuit when merge is blocked
+
+When `gh pr merge` fails with "base branch policy prohibits the merge":
+1. **Do NOT investigate, reason about, or run diagnostic commands.** The cause is almost always unresolved review threads.
+2. **Immediately respond with exactly this** (filling in the PR number):
+   > Merge blocked — unresolved review threads. Please resolve them here:
+   > https://github.com/blamechris/repo-relay/pull/{N}/files
+   >
+   > Say "done" when resolved.
+3. **Wait for user confirmation**, then retry `gh pr merge --squash`.
+4. If it fails a second time, THEN check `gh pr checks` for CI failures.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Adds the merge-gate pattern to CLAUDE.md under PR Workflow
- Short-circuits diagnostic reasoning when `gh pr merge` fails due to branch protection
- Directs user to resolve review threads immediately instead of investigating

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Pattern matches the generic template from skill-templates