### PR TITLE
chore(ci): run CI on all PRs, not just those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   check:


### PR DESCRIPTION
Remove `branches: [main]` filter from `pull_request` trigger so CI runs on all PRs regardless of target branch.