### PR TITLE
docs: add REPO_RELAY_SESSION_MAX_WAIT to env var table (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,7 @@ npm run lint      # Run ESLint
 | `DISCORD_CHANNEL_RELEASES` | No | Channel ID for releases (defaults to PRS channel) |
 | `GITHUB_TOKEN` | Yes | For GitHub API access (review detection) |
 | `STATE_DIR` | No | Custom state directory (default: `~/.repo-relay`) |
+| `REPO_RELAY_SESSION_MAX_WAIT` | No | Max ms to wait for Discord session limit reset (default: `300000` = 5 min). Set to `0` to fail immediately. |
 
 ## Code Patterns
 


### PR DESCRIPTION
## Summary
- Adds `REPO_RELAY_SESSION_MAX_WAIT` to the Environment Variables table in CLAUDE.md

Closes #123