### PR TITLE
security(actions): pin actions/setup-node and actions/checkout to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20'
 


### PR DESCRIPTION
## Summary

- Pin `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020` in `action.yml` so consumers with `sha_pinning_required: true` (e.g. `blamechris/chroxy`) can invoke this composite action.
- Pin `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5` in `.github/workflows/ci.yml` for consistency.

Tag refs can be force-moved by the action owner; full-length SHA refs cannot, which is why GitHub's `sha_pinning_required` enforcement transitively rejects tag refs inside composite actions consumed by a hardened repo.

## Context

`blamechris/chroxy#3819` rolled back repo-level `sha_pinning_required: true` because every run of `.github/workflows/repo-relay.yml` over there failed with:

```
##[error]The action actions/setup-node@v4 is not allowed in blamechris/chroxy because all actions must be pinned to a full-length commit SHA.
```

After this PR merges, a new tag (e.g. `v1.0.1`, with `v1` fast-forwarded) will let chroxy bump its `repo-relay@<SHA>` reference and re-enable `sha_pinning_required`.

## Test plan

- [ ] CI passes on this PR (validates the two pinned SHAs resolve and run identically)
- [ ] After merge: tag `v1.0.1`, move `v1` forward, then bump `blamechris/chroxy/.github/workflows/repo-relay.yml` to the new SHA and re-enable repo-level enforcement