### PR TITLE
security(ci): SHA-pin self-reference in repo-relay workflow (#126)

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -26,7 +26,7 @@ jobs:
       (github.event_name != 'workflow_run' ||
        github.event.workflow_run.pull_requests[0] != null)
     steps:
-      - uses: blamechris/repo-relay@v1
+      - uses: blamechris/repo-relay@3a08a89260c725dffc11026f1d31edf874b0e0d9 # v1.0.2
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary
Pins the dogfooded self-reference in `.github/workflows/repo-relay.yml` from the mutable `@v1` tag to the full commit SHA, per the convention established in #125.

Pinned to `3a08a89` and tagged `v1.0.2` (the post-merge-wave state of main, including all 12 fixes from #132–#143).

## Notes
- Future `v1` tag moves should bump this reference alongside the consumer bump in chroxy.

Closes #126

## Test plan
- [x] Workflow-file-only change; CI exercises the unchanged test/lint/dist jobs