### PR TITLE
chore(ci): persist repo-relay state via actions/cache; bump self-pin to v1.1.0

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -15,6 +15,10 @@ on:
   release:
     types: [published]
 
+# Serialize runs — concurrent jobs would race on the state cache
+concurrency:
+  group: repo-relay-${{ github.repository }}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -26,7 +30,16 @@ jobs:
       (github.event_name != 'workflow_run' ||
        github.event.workflow_run.pull_requests[0] != null)
     steps:
-      - uses: blamechris/repo-relay@3a08a89260c725dffc11026f1d31edf874b0e0d9 # v1.0.2
+      # Persist SQLite state between runs. Per-run key: cache entries are
+      # immutable, so a constant key would freeze state at the first run.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.repo-relay
+          key: repo-relay-state-${{ github.repository }}-${{ github.run_id }}
+          restore-keys: |
+            repo-relay-state-${{ github.repository }}-
+
+      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary
Adopts the state-persistence recipe documented in the README (#132): `actions/cache` (SHA-pinned) with a per-run key + `restore-keys` prefix so each run restores the latest snapshot and saves a new one (cache entries are immutable — a constant key would freeze state at the first run). Workflow-level `concurrency` group serializes runs so concurrent jobs can't race on the cache.

Until now every dogfood run started with an empty DB and leaned on channel-search recovery (visible as "Recovered message + status" in every run log). With the cache, state is exact across runs.

Also bumps the self-reference `v1.0.2` → `v1.1.0` (`f08840b`) per the convention established in #126.

## Test plan
- [x] Workflow-only change; CI exercises the standard jobs
- [ ] Post-merge: next two notify runs — first saves the cache, second restores it (log shows the state dir without a recovery line)