### PR TITLE
docs: document cache ref-scoping; fix stale data-at-rest note

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ jobs:
 **Notes:**
 - The `concurrency` group serializes repo-relay runs — without it, simultaneous events (e.g. a push and its CI completing) can race and create duplicate embeds or lose status updates
 - Cache evicts after 7 days of inactivity (fine for active repos)
-- The cached DB stores Discord message IDs plus PR/issue metadata — including issue bodies and logged event payloads. For private repos this means repo content sits in the Actions cache at rest; if that matters for your threat model, skip the cache (the bot falls back to channel search)
+- **Caches are ref-scoped**: runs on a PR's merge ref see that PR's saves plus the default branch's, but not other PRs'. In practice the chatty sequences (pushes, reviews, comments on one PR) share the PR's scope, and default-branch events (issues, releases, `workflow_run`) share the default scope — state written in one scope reaches the other only via channel-search recovery
+- The cached DB stores Discord message IDs plus PR/issue metadata (titles, bodies, branch names). For private repos this means repo content sits in the Actions cache at rest; if that matters for your threat model, skip the cache (the bot falls back to channel search)
 - If cache misses, repo-relay falls back to searching the last 100 channel messages
 
 ## State Storage


### PR DESCRIPTION
## Summary
Two accuracy fixes to the README's state-persistence section, prompted by review feedback on chroxy#5428:

- **Ref-scoping caveat**: Actions caches are scoped per ref — PR merge refs see their own saves plus the default branch's, not other PRs'. The recipe's benefit is per-scope (which covers the chatty same-PR sequences); cross-scope gaps fall back to channel-search recovery. The previous wording implied global persistence.
- **Stale data-at-rest note**: the DB no longer stores logged event payloads (removed in #141) — the note now lists what's actually cached (titles, bodies, branch names).

## Test plan
- [x] Docs-only change