### PR TITLE
chore: commit local dev tooling (skills + repo-memory MCP)

### DIFF
--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -1,0 +1,407 @@
+# /autonomous-dev-flow
+
+Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next issue. The user reviews and merges PRs asynchronously while work continues.
+
+## Arguments
+
+- `$ARGUMENTS` - Issue source and options. Examples:
+  - `label:ready-to-build` (all open issues with this label)
+  - `milestone:"v1.2"` (all open issues in milestone)
+  - `#12 #15 #18` or `12 15 18` (specific issues by number)
+  - `label:ready-to-build max:5 sort:created-asc` (with options)
+  - If empty, auto-detect: scan open issues sorted by complexity (low first, then medium, skip high)
+  - Options: `max:N` (default 10, hard cap 15), `sort:created-asc` (default) or `sort:created-desc`
+
+## Instructions
+
+### Phase 0: Queue Setup
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+BRANCH_PREFIX="auto/"
+```
+
+Parse `$ARGUMENTS` to determine the issue source:
+
+- **Explicit list**: Strip `#` prefixes, run `gh issue view ${NUM} --json number,title,state,labels,body,assignees` for each
+- **Label**: `gh issue list --label "${LABEL}" --state open --json number,title,labels,assignees --limit ${MAX}`
+- **Milestone**: `gh issue list --milestone "${MILESTONE}" --state open --json number,title,labels,assignees --limit ${MAX}`
+- **Auto-detect** (empty args): `gh issue list --state open --json number,title,labels,assignees --limit 30` then sort by complexity label (low first, then medium, skip high)
+
+Apply sort order and cap to `max` (hard cap 15 — sessions beyond this rarely maintain quality). Recommended: 3-5 issues for first use; sessions of 10+ work best with well-specified, low-complexity issues.
+
+**Filter out assigned issues** — exclude issues with assignees from the working queue. Show them in the queue table as informational but don't process them.
+
+**Validate the queue before starting:**
+- At least 1 issue must be open and unassigned
+- If all matching issues are assigned, report "All N matching issues are assigned — nothing to process" and stop
+- If 0 issues match, report and stop — don't start an empty session
+- Show the user the queue and get confirmation before entering the loop
+
+```markdown
+## Work Queue ({N} issues, {M} skipped as assigned)
+
+| # | Issue | Labels | Action |
+|---|-------|--------|--------|
+| 1 | #12 — Add retry logic to API client | enhancement | Implement |
+| 2 | #15 — Add leaderboard system | complexity:high | Decompose → sub-issues |
+| — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
+| 3 | #18 — Add integration tests for auth flow | testing | Implement |
+
+Start autonomous dev session?
+```
+
+Wait for user confirmation. **This is the ONLY confirmation point** — everything after runs autonomously.
+
+After confirmation, create task list tracking:
+```
+For each issue in work queue:
+  TaskCreate: "Issue #N — <title>" with status pending
+```
+
+### Phase 0.5: Auto-Decompose High-Complexity Issues
+
+When the queue contains issues that are too large to implement directly (e.g., labeled `complexity:high` or equivalent), decompose them into smaller, independently implementable sub-issues BEFORE entering the core loop.
+
+For each high-complexity issue:
+
+0. Check for prior decomposition — scan the issue's comments for an existing "Decomposed into #A, #B, #C" comment. If found, use those existing sub-issues instead of creating new ones.
+1. Read the full issue body: `gh issue view ${ISSUE_NUM} --json body,comments -q .`
+2. Understand the full scope — files involved, systems affected, testing needs
+3. Break into 2-5 sub-issues, each low or medium complexity
+4. Create sub-issues via `gh issue create`:
+
+```bash
+SUB_URL=$(gh issue create \
+  --title "type(scope): Sub-task description" \
+  --label "enhancement" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Specific sub-task description.
+
+Part of #${ISSUE_NUM}
+
+## Implementation Plan
+
+- Files to modify: `src/path/to/file`
+- Test strategy: Add tests for X behavior
+- Approach: [specific implementation details]
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+EOF
+)")
+
+SUB_NUM=$(basename "$SUB_URL")
+```
+
+5. Insert sub-issues at FRONT of queue (context is fresh from reading the parent)
+6. Comment on parent issue: `gh issue comment ${ISSUE_NUM} --body "Decomposed into #A, #B, #C — each independently implementable with TDD."`
+7. Parent stays open until all sub-issues merge — do NOT close it
+8. After decomposition, if the total queue exceeds 15, truncate to 15 with a message: "Queue expanded to N issues after decomposition. Processing first 15."
+
+**Skip criteria** — auto-skip these issues (log reason in progress table):
+- Empty issue body or no identifiable acceptance criteria — needs requirements before implementation
+- No code path (manual testing, design docs, decisions needed)
+- Requires user input not present in the description
+- Deployment/release tasks
+- Issues labeled `blocked` or `wontfix`
+- Issues requiring design decisions with multiple valid approaches not specified
+
+If skipping, comment on the issue:
+
+```bash
+gh issue comment ${ISSUE_NUM} --body "Skipped during autonomous dev session — [reason]. Needs manual attention."
+```
+
+### Phase 1: Sync Check (before EACH issue)
+
+```bash
+git checkout main
+git pull origin main
+```
+
+Check for any PRs merged by the user since last check:
+
+```bash
+gh pr list --state merged --json number,headRefName,mergedAt --limit 20 \
+  | jq --arg prefix "${BRANCH_PREFIX}" '[.[] | select(.headRefName | startswith($prefix))]'
+```
+
+Note any merged PRs in the progress table. If on a stale branch, switch back to main.
+
+Check for existing branches/PRs from a previous session for the current issue:
+
+```bash
+# Check if issue already has a PR (search by title reference)
+gh pr list --json number,title,headRefName,state --limit 50 \
+  | jq --arg num "${ISSUE_NUM}" '[.[] | select(.title | contains("#" + $num))]'
+
+# Also check by branch prefix
+gh pr list --json number,title,headRefName,state --limit 50 \
+  | jq --arg prefix "${BRANCH_PREFIX}" '[.[] | select(.headRefName | startswith($prefix))]'
+```
+
+- Already merged → mark as done, skip
+- Open PR exists → skip (user can re-queue if needed)
+- Stale branch, no PR → delete branch, re-process
+
+### Phase 2: Issue Understanding
+
+```bash
+gh issue view ${ISSUE_NUM} --json title,body,labels,comments
+```
+
+Read the full issue. Identify:
+- **Files to modify** — use Glob/Grep to find relevant code
+- **Test strategy** — what behavior to test, where tests go
+- **Implementation approach** — minimal path to satisfy acceptance criteria
+
+Explore the codebase to understand the relevant code before writing anything:
+
+```bash
+# Read CLAUDE.md for project conventions
+cat CLAUDE.md 2>/dev/null
+
+# Explore relevant files based on issue description
+```
+
+If the issue body is empty or has no actionable requirements, apply skip criteria from Phase 0.5.
+
+### Phase 3: Implementation (TDD)
+
+Create branch following project conventions:
+
+```bash
+# Generate slug from issue title: lowercase, hyphens, no special chars, max 40 chars
+ISSUE_TITLE=$(gh issue view "${ISSUE_NUM}" --json title -q '.title')
+SLUG=$(printf '%s' "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+
+# Create branch from issue number + slug
+BRANCH="${BRANCH_PREFIX}${ISSUE_NUM}-${SLUG}"
+git checkout -b "${BRANCH}"
+```
+
+**CRITICAL: Always branch from main.** Never stack branches — each PR must be independently mergeable in any order.
+
+#### RED — Write Failing Tests First
+
+Based on the issue's acceptance criteria, write tests that describe the desired behavior. Tests MUST fail before any implementation.
+
+```bash
+npm test
+
+# Test files follow __tests__/*.test.ts convention
+```
+
+If tests pass immediately, the behavior already exists — investigate before proceeding. Either the issue is already resolved or the tests don't capture the right behavior.
+
+#### GREEN — Make Tests Pass
+
+Write the minimum implementation to make all new tests pass. Don't over-engineer — just satisfy the tests.
+
+```bash
+# Run tests to confirm they pass
+npm test
+```
+
+If tests still fail, iterate on the implementation until they pass. Do NOT move to REFACTOR until all tests are green.
+
+#### REFACTOR — Clean Up
+
+With green tests as a safety net:
+- Remove duplication
+- Improve naming
+- Simplify logic
+- Ensure the code follows project conventions (per CLAUDE.md)
+
+```bash
+# Run tests again to confirm refactoring didn't break anything
+npm test
+
+npm run typecheck
+```
+
+### Phase 4: Commit and PR Creation
+
+Stage and commit with conventional format:
+
+```bash
+# Stage relevant files (never git add -A)
+git add <specific-files>
+
+# Commit with issue reference — NO attribution
+git commit -m "$(cat <<'EOF'
+type(scope): description
+
+Implements the core change described in the issue.
+
+Refs #${ISSUE_NUM}
+EOF
+)"
+
+# Commit scopes: discord, github, db, cli, core
+
+git push -u origin ${BRANCH}
+```
+
+Create PR autonomously (NO user confirmation — PRs are the async checkpoints):
+
+```bash
+# Construct PR title: conventional commit format referencing the issue
+# Infer type from issue labels (bug→fix, enhancement→feat, etc.)
+ISSUE_LABELS=$(gh issue view "${ISSUE_NUM}" --json labels -q '[.labels[].name] | join(",")')
+case "${ISSUE_LABELS}" in
+  *bug*) PR_TYPE="fix" ;;
+  *test*) PR_TYPE="test" ;;
+  *refactor*) PR_TYPE="refactor" ;;
+  *) PR_TYPE="feat" ;;
+esac
+PR_TITLE="${PR_TYPE}: ${ISSUE_TITLE} (#${ISSUE_NUM})"
+
+PR_URL=$(gh pr create \
+  --title "${PR_TITLE}" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Change 1
+- Change 2
+
+Refs #${ISSUE_NUM}
+
+## Test Plan
+
+- [ ] All new tests pass
+- [ ] Existing tests unbroken
+- [ ] TypeScript type-checks clean
+- [ ] npm run build succeeds
+EOF
+)")
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+```
+
+### Phase 5: Full Review
+
+**Pre-Skill Checkpoint** (MANDATORY — prevents context drift in long sessions):
+1. Re-read CLAUDE.md for project conventions
+2. Re-read the skill files for /full-review, /agent-review, and /check-pr
+
+Run `/full-review ${PR_NUM}`:
+- Phase 1: Agent review — deep expert review against project standards
+- Phase 2: Check-PR — process all review comments (Copilot + agent-review findings)
+
+Capture results: verdict, findings counts, fixes committed, issues created/closed.
+
+**If critical findings exist:** Fix them (standard /full-review behavior handles this). Two fix attempts max — after that, flag the PR as "Needs attention" and move on.
+
+**Merge through the Unattended Merge Gate** (see `/unattended-merge`). If the verdict is clean, ALL CI checks (`check (20)`, `check (22)`, `dist-freshness`) pass on the final commit, and ALL review threads are resolved, squash-merge, verify the PR reports `MERGED`, update the `v1` tag, and record the merge as an entry in the final session report. NEVER use `gh pr merge --auto` or GitHub auto-merge — verify the gates first, then merge synchronously. If any gate fails, do NOT merge: flag the PR for the user with the failed gate named and keep working.
+
+### Phase 6: Assess, Report, and Continue
+
+Based on /full-review results, classify the PR:
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| Clean | No critical findings, all comments addressed | Edit PR body: `Refs` → `Closes`. Merge via the Unattended Merge Gate, record the entry, mark issue done, continue |
+| Needs attention | Critical findings or unresolved comments | Keep `Refs` (don't auto-close). Flag for user, continue |
+| Broken | Tests failing after review fixes | Keep `Refs` (don't auto-close). Flag for user, continue |
+
+Update task tracking:
+
+```
+TaskUpdate: "Issue #N" → completed (or flagged)
+```
+
+Output cumulative progress table:
+
+```markdown
+## Session Progress ({completed}/{total})
+
+| # | Issue | Branch | PR | Review | Status |
+|---|-------|--------|----|--------|--------|
+| 1 | #12 — Add retry logic | 12-add-retry | #45 | Approve (0 critical) | Done |
+| 2 | #15 — Add leaderboard | — | — | — | Decomposed → #20, #21 |
+| 3 | #20 — Leaderboard data model | 20-lb-model | #46 | Approve (1 suggestion) | Done |
+| 4 | #18 — Add auth tests | — | — | — | In progress |
+| 5 | #22 — Update error handling | — | — | — | Queued |
+```
+
+**CRITICAL: Never block the session on a flagged PR.** Flag and move on. The user handles flagged PRs during check-ins.
+
+Return to Phase 1 for next issue.
+
+### Phase 7: Session Summary
+
+After all issues are processed (or the queue is exhausted), output final summary:
+
+```markdown
+## Autonomous Dev Session Complete
+
+**Issues processed:** {N}
+**Queue source:** {description}
+
+### Results
+
+| # | Issue | PR | Review Verdict | Status |
+|---|-------|----|---------------|--------|
+| 1 | #12 — Add retry logic | [#45](url) | Approve | Merged (`abc1234`) |
+| 2 | #15 — Add leaderboard | — | — | Decomposed → #20, #21, #22 |
+| 3 | #20 — Leaderboard data model | [#46](url) | Approve | Merged (`def5678`) |
+| 4 | #18 — Add auth tests | [#47](url) | Request Changes | Needs attention |
+
+### Summary
+- **Merged this session:** N PRs — one entry each under "Merged by this session" (PR, issue, verdict, checks, merge SHA); MANDATORY per the Unattended Merge Gate
+- **Needs attention:** M PRs (details below)
+- **Decomposed:** K issues → L sub-issues created
+- **Skipped:** J issues (reasons below)
+- **Issues created during reviews:** #A, #B, #C
+- **PRs merged by user during session:** #X, #Y
+
+### Needs Attention
+- **PR #47** (#18 — Add auth tests): 1 critical finding — auth token not validated before use. See review comment.
+
+### Skipped Issues
+- **#25**: Requires deployment setup — not automatable
+- **#30**: Needs user decision on provider choice
+
+### Next Steps
+- Merge ready PRs
+- Address flagged PRs
+- Review created issues for follow-up work
+```
+
+## Resume Strategy
+
+This skill uses **GitHub state** for resume — no local state files.
+
+If a session is interrupted (crash, timeout, user stops it), re-running with the same arguments will:
+
+1. Query GitHub for existing session branches (matching `BRANCH_PREFIX`) and PRs referencing each issue
+2. Skip issues that already have merged or open PRs
+3. Resume from the first issue without a PR
+
+This makes the skill **idempotent** — safe to re-run without duplicating work.
+
+## Critical Rules
+
+1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions anywhere. Zero Attribution Policy.
+2. **TDD is mandatory** — RED → GREEN → REFACTOR for every issue. No skipping tests. If pure docs/config, note why tests are N/A.
+3. **Branch from main every time** — Never stack branches. Each PR is independently mergeable in any order.
+4. **One confirmation point** — The initial queue approval. Everything after is fully autonomous.
+5. **Merge only through the Unattended Merge Gate** — /full-review clean + ALL checks green on the final commit + ALL review threads resolved. No `gh pr merge --auto`, no protection overrides. A failed gate means flag, don't merge. Every self-merged PR MUST appear as an entry in the final session report, and every merge is followed by the `v1` retag.
+6. **Never block on review findings** — Flag and move on. The user handles flagged PRs during check-ins.
+7. **Two fix attempts max** — If /full-review finds critical issues, fix them. If a second attempt still fails, flag and move on.
+8. **Progress table after every issue** — The user may check in at any time. The table must be current.
+9. **Respect the hard cap** — Max 15 issues per session. Refuse larger queues.
+10. **Resume from GitHub state** — No local state files. Query branches matching `BRANCH_PREFIX` and PR titles to detect prior work.
+11. **Compose existing skills** — /full-review is called as-is (chains /agent-review → /check-pr). Don't reinvent their logic.
+12. **Decompose, don't skip** — High-complexity issues get broken into sub-issues, not skipped. Only skip truly non-automatable work.
+13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
+14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
+15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
+<!-- skill-templates: autonomous-dev-flow 5ed9260 2026-06-10 -->

--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -1,0 +1,337 @@
+# /start-working
+
+Scan all work sources — GitHub issues, open PRs, roadmap files, audit outputs, codebase TODOs — to determine what to work on next. If nothing actionable is found, perform a lightweight codebase audit to surface potential investigations.
+
+This skill is **read-only** — it never writes files, creates issues, or commits. It's a triage tool that feeds naturally into `/autonomous-dev-flow` or manual work.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional filters. Space-separated tokens:
+  - `focus=AREA` — Narrow to a specific area (e.g., `focus=testing`, `focus=security`, `focus=performance`)
+  - `limit=N` — Max items to show per source (default: 10)
+  - `include-closed` — Also scan recently closed issues (last 7 days) for context
+  - If empty, scan everything with defaults
+
+Examples:
+```
+/start-working
+/start-working focus=testing
+/start-working limit=5
+/start-working focus=security include-closed
+```
+
+## Instructions
+
+### 0. Setup
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO_NAME=$(basename "$REPO")
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+Parse `$ARGUMENTS` for `focus`, `limit` (default 10), and `include-closed` flag.
+
+Read CLAUDE.md and any `.claude/rules/` files to understand the project's conventions, priorities, and known issues.
+
+### 1. Gather Work Sources
+
+Collect data from all sources. Run independent queries in parallel where possible.
+
+#### 1a. GitHub Issues
+
+```bash
+# Open issues sorted by updated date (most recent activity first)
+gh issue list --state open --json number,title,labels,assignees,milestone,createdAt,updatedAt --limit 50
+
+# If include-closed flag set, also grab recently closed for context
+gh issue list --state closed --json number,title,labels,closedAt --limit 20
+```
+
+Categorize each open issue:
+
+| Category | Detection |
+|----------|-----------|
+| Blocked | Has label matching: `blocked`, `wontfix` |
+| Assigned | Has assignees (someone is already working on it) |
+| Ready | Issues with `complexity:low` or `complexity:medium` AND `testing:low` or `testing:medium` labels |
+| Backlog | Open, unassigned, not blocked, but no explicit "ready" signal |
+
+For "Ready" and "Backlog" issues, read the issue body to check for acceptance criteria:
+
+```bash
+gh issue view ${ISSUE_NUM} --json body -q .body
+```
+
+Issues with clear acceptance criteria rank higher than vague ones.
+
+#### 1b. Open PRs Needing Attention
+
+```bash
+# All open PRs with review and check status
+gh pr list --state open --json number,title,author,reviewDecision,isDraft,headRefName,createdAt,updatedAt --limit 20
+```
+
+Flag PRs that need attention:
+
+| Signal | Meaning |
+|--------|---------|
+| `reviewDecision: CHANGES_REQUESTED` | Review feedback needs addressing |
+| `isDraft: true` | Work in progress — may be stale |
+| Stale (no update in 7+ days) | Forgotten PR — needs decision (finish, close, or rebase) |
+
+Also check CI status for open PRs:
+
+```bash
+# For each open PR, check if CI is failing
+gh pr checks ${PR_NUM} --json name,state --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")]'
+```
+
+#### 1c. Roadmap and Planning Files
+
+Scan for planning documents in common locations:
+
+```bash
+# Common roadmap/planning file patterns
+```
+
+Search for these files (check existence, don't fail if missing):
+- `ROADMAP.md`, `TODO.md`, `CHANGELOG.md` (for recent/planned entries)
+- `docs/roadmap/`, `docs/planning/`, `docs/TODO/`
+
+For each found file, scan for:
+- Unchecked items (`- [ ]`)
+- Sections labeled "Planned", "Next", "Upcoming", "TODO", "Backlog"
+- Items not yet represented as GitHub issues
+
+#### 1d. Audit Output Files
+
+Check for existing audit reports:
+
+```bash
+# Look for project-audit output
+ls docs/project-audit/ 2>/dev/null
+ls docs/audits/ 2>/dev/null
+
+# Also check for from-audit issues that are still open
+gh issue list --state open --label "from-audit" --json number,title,labels --limit 20 2>/dev/null
+
+# And from-review issues (deferred work from PR reviews)
+gh issue list --state open --label "from-review" --json number,title,labels --limit 20 2>/dev/null
+```
+
+If audit reports exist, read the master assessment for any unaddressed recommendations (check if corresponding issues exist).
+
+#### 1e. Codebase TODOs
+
+Scan for TODO/FIXME/HACK markers in source code:
+
+```bash
+# Search for actionable markers in TypeScript source files
+find src -name "*.ts" -type f -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
+```
+
+Use Grep to find `TODO`, `FIXME`, `HACK`, `XXX`, and `WORKAROUND` markers in source files. Exclude:
+- `node_modules/`, `.godot/`, `build/`, `dist/`, vendor directories
+- Test fixtures and generated files
+- Lock files
+
+Collect file path, line number, and the marker text for each hit.
+
+### 2. Prioritize and Deduplicate
+
+#### 2a. Assign Priority Tiers
+
+Map every finding to a unified priority tier:
+
+| Tier | Label | Signals |
+|------|-------|---------|
+| P0 | Immediate | PRs with `CHANGES_REQUESTED`, open `bug`/`critical` issues, failing CI on open PRs, Discord API rate limiting issues |
+| P1 | High | `complexity:low` + `testing:low` issues, `from-review` issues, milestone-assigned issues, stale PRs |
+| P2 | Normal | `enhancement` issues with acceptance criteria, `from-audit` issues, roadmap items |
+| P3 | Exploratory | Codebase TODOs, vague issues without criteria, audit recommendations without issues, `testing:high` issues |
+
+If `focus=AREA` was specified, boost items matching that area by one tier (P2→P1, P3→P2).
+
+#### 2b. Deduplicate
+
+Cross-reference findings across sources:
+- If a roadmap item already has a GitHub issue → keep the issue, drop the roadmap entry (note the link)
+- If an audit recommendation already has a `from-audit` issue → keep the issue, drop the audit entry
+- If a TODO in code references an issue number (e.g., `TODO(#42)`) → link to the issue, don't list separately
+- If multiple TODOs relate to the same theme → group them as one item
+
+#### 2c. Apply Focus Filter
+
+If `focus=AREA` is set, filter to only show items related to that area. Match against:
+- Issue labels
+- Issue title/body keywords
+- File paths (e.g., `focus=testing` matches test files)
+- TODO context
+
+### 3. Present Work Queue
+
+Output the primary summary table, then detail sections for each source.
+
+#### Primary Output — Work Queue Table
+
+```markdown
+## What's Next for ${REPO_NAME}
+
+**Sources scanned:** GitHub issues, open PRs, roadmap files, audit outputs, codebase TODOs
+**Found:** ${TOTAL_ITEMS} actionable items across ${SOURCE_COUNT} sources
+
+### Work Queue
+
+| Priority | Source | Item | Why |
+|----------|--------|------|-----|
+| P0 | PR | #45 — Failing CI, changes requested | Review feedback unaddressed for 3 days |
+| P0 | Issue | #12 — Login broken on Android | Bug, reported 2 days ago |
+| P1 | Issue | #18 — Add retry logic to API | from-review, has acceptance criteria |
+| P1 | PR | #38 — Draft PR stale 14 days | Needs decision: finish or close |
+| P2 | Issue | #25 — Improve error messages | enhancement, milestone v1.2 |
+| P2 | Roadmap | Add rate limiting | In ROADMAP.md, no issue yet |
+| P3 | TODO | 5× FIXME in src/auth/ | Scattered workarounds for token refresh |
+| P3 | Audit | Upgrade vulnerable deps | From project-audit, no issue created |
+```
+
+#### Detail Sections
+
+After the summary table, provide detail sections only for sources that had findings:
+
+**GitHub Issues** (if any):
+```markdown
+### Open Issues ({N} total, {M} ready, {K} blocked)
+
+**Ready to work on:**
+- #18 — Add retry logic to API (`from-review`, `complexity:low`) — has 3 acceptance criteria
+- #25 — Improve error messages (`enhancement`) — milestone v1.2
+
+**Blocked / Needs input:**
+- #30 — Choose auth provider (`needs-design`) — requires decision
+- #35 — Blocked by #18 (`blocked`)
+
+**Assigned (in progress):**
+- #22 — Refactor auth module — assigned to @user
+```
+
+**Open PRs** (if any):
+```markdown
+### Open PRs Needing Attention ({N})
+
+- **#45** — Fix login flow: Changes requested 3 days ago, CI failing
+- **#38** — Add caching layer: Draft, no updates in 14 days
+```
+
+**Roadmap Items** (if any):
+```markdown
+### Roadmap Items Not Yet Tracked ({N})
+
+Items from planning docs without corresponding GitHub issues:
+- Add rate limiting (ROADMAP.md line 42)
+- Implement offline mode (ROADMAP.md line 58)
+```
+
+**Codebase TODOs** (if any):
+```markdown
+### Codebase TODOs ({N} markers across {M} files)
+
+| Marker | Count | Top Locations |
+|--------|-------|---------------|
+| TODO | 12 | src/auth/ (5), src/api/ (4), src/utils/ (3) |
+| FIXME | 3 | src/auth/token.js (2), src/db/migrate.js (1) |
+| HACK | 1 | src/api/retry.js:42 |
+```
+
+#### Recommended Next Action
+
+End with a concrete recommendation:
+
+```markdown
+### Recommended Next Action
+
+Based on the work queue:
+- **If you want to fix what's broken:** Address P0 items first — {description}
+- **If you want to build features:** Run `/autonomous-dev-flow {issue_numbers}` for the P1/P2 ready issues
+- **If you want to clean up:** The {N} TODOs in src/auth/ suggest a refactoring pass
+```
+
+### 4. Quick Audit (Fallback — Only If Queue Is Empty)
+
+**ONLY run this phase if Phases 1-3 found zero actionable items.** If there were any issues, PRs, roadmap items, or TODOs, skip this phase entirely.
+
+When the queue is truly empty, perform a lightweight codebase scan to surface potential investigations. This is NOT a full project audit — it's a quick check across a few dimensions.
+
+#### 4a. Test Coverage Gaps
+
+```bash
+# Check test coverage with npm test and typecheck
+npm test
+npm run typecheck
+```
+
+- Check which source directories have corresponding test files
+- Identify source files with no test counterpart
+- Look for test files that are empty or minimal (< 5 assertions)
+
+#### 4b. Dependency Health
+
+```bash
+# Check for outdated dependencies and vulnerabilities
+npm outdated
+npm audit
+```
+
+- Count outdated dependencies
+- Check for known vulnerabilities if tooling is available (`npm audit`, `pip-audit`, etc.)
+
+#### 4c. Code Quality Signals
+
+Quick scan for potential issues:
+- Files over 500 lines (may need splitting)
+- Functions/methods over 50 lines (may need refactoring)
+- Deeply nested code (4+ levels of indentation)
+- Duplicated patterns across files
+
+#### 4d. Documentation Gaps
+
+- README.md: is it up to date? Does it cover setup, usage, contributing?
+- API documentation: are public interfaces documented?
+- Architecture: any `docs/architecture/` or ADR files?
+
+#### 4e. Present Quick Audit Results
+
+```markdown
+## Quick Audit — Potential Investigations
+
+No actionable items found in the standard work sources. Here's what a quick codebase scan revealed:
+
+| Area | Status | Finding |
+|------|--------|---------|
+| Test Coverage | ⚠️ | {N} source files have no test counterpart |
+| Dependencies | ✅ | All up to date |
+| Code Quality | ⚠️ | {N} files over 500 lines |
+| Documentation | ⚠️ | README missing setup instructions |
+
+### Suggested Investigations
+
+1. **Add tests for {module}** — {N} files in `src/{path}/` have no tests. Effort: M
+2. **Split {file}** — {file} is {N} lines. Consider extracting {concept}. Effort: S
+3. **Update README** — Missing: setup instructions, environment variables. Effort: S
+
+### Want a Deep Audit?
+
+Run `/project-audit` for a comprehensive multi-agent analysis with detailed recommendations.
+```
+
+## Critical Rules
+
+1. **Read-only** — This skill NEVER writes files, creates issues, creates PRs, or commits. It is purely informational. The user decides what to act on.
+2. **Quick, not deep** — Phase 1-3 should complete in under 2 minutes. The fallback audit (Phase 4) adds 1-2 minutes. This is NOT `/project-audit`.
+3. **Prioritize actionability** — Items with clear acceptance criteria and "ready" signals rank above vague ideas. The user should be able to pick the top item and start working immediately.
+4. **Deduplicate across sources** — Never show the same work item from multiple sources. Link them instead.
+5. **Graceful degradation** — If a source is unavailable (no `gh` auth, no roadmap file, no audit reports), skip it silently and note it in the sources summary. Never fail on a missing source.
+6. **Respect blocked/assigned** — Show blocked and assigned items for context but clearly separate them from the actionable queue. Never recommend working on a blocked or assigned item.
+7. **Composable output** — The "Recommended Next Action" section should include copy-pasteable commands (e.g., `/autonomous-dev-flow #12 #18 #25`) so the user can immediately act on the findings.
+8. **No file writes** — The fallback audit in Phase 4 outputs to the conversation only. Unlike `/project-audit`, it does NOT write report files or create a `docs/` directory.
+<!-- skill-templates: start-working 59a26f3 2026-02-26 -->

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "repo-memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@blamechris/repo-memory"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,10 @@ git push origin v1
 
 Consumers reference `uses: blamechris/repo-relay@v1` which resolves to this tag.
 
+## Repo Memory MCP
+
+The `repo-memory` MCP is available. Prefer `get_file_summary` over `Read` when exploring code you won't edit — it returns cached summaries and saves tokens. Also available: `get_project_map`, `get_related_files`, `search_by_purpose`. Use `Read` when you need exact lines or plan to edit. When launching subagents, tell them repo-memory tools are available.
+
 ### Key Files for Debugging
 
 | File | Purpose |


### PR DESCRIPTION
Commits finished local dev-tooling artifacts that have been sitting uncommitted.

## Changes

**Skills** (`feat(skills)`)
- `autonomous-dev-flow.md` — completes the unattended-merge integration. PR #167 ported `tackle-issues` and `unattended-merge` from the registry but left this one as an untracked local file. It **is** referenced by `tackle-issues.md` (which composes its logic). Lint-clean, stamp `5ed9260`.
- `start-working.md` — read-only triage skill (scans issues/PRs/TODOs to pick next work) that feeds into `autonomous-dev-flow`. Standalone; not yet referenced elsewhere. Lint-clean, stamp `59a26f3`.

**repo-memory MCP** (`chore`)
- `.mcp.json` — registers the `@blamechris/repo-memory` stdio server.
- `CLAUDE.md` — usage note steering subagents toward cached summaries over full Reads.

## Verification
- `npm run typecheck` — clean
- `npm run build` — clean, no `dist/` drift (non-source changes only)
- `npm test` — 383/383 pass
- Both skills pass `skill-lint.sh` (guards + stamps ok)

## Review notes
Copilot flagged four cosmetic nits (unused `REPO`/`DEFAULT_BRANCH` setup vars; `limit` arg documented but not applied in the body). These are pre-existing in the **registry templates** — the committed files faithfully match the registry, so fixing them here would create drift and break the stamps. Routed upstream as blamechris/skill-templates#99 for a fix-at-source + re-port.