### PR TITLE
chore(skills): re-port start-working + autonomous-dev-flow (skill-templates#99)

### DIFF
--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -17,8 +17,6 @@ Orchestrate long-running autonomous dev sessions — work through GitHub issues 
 ### Phase 0: Queue Setup
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-
 BRANCH_PREFIX="auto/"
 ```
 
@@ -404,4 +402,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
 15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
-<!-- skill-templates: autonomous-dev-flow 5ed9260 2026-06-10 -->
+<!-- skill-templates: autonomous-dev-flow 5df829a 2026-06-12 -->

--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -9,7 +9,7 @@ This skill is **read-only** — it never writes files, creates issues, or commit
 - `$ARGUMENTS` - Optional filters. Space-separated tokens:
   - `focus=AREA` — Narrow to a specific area (e.g., `focus=testing`, `focus=security`, `focus=performance`)
   - `limit=N` — Max items to show per source (default: 10)
-  - `include-closed` — Also scan recently closed issues (last 7 days) for context
+  - `include-closed` — Also scan recently closed issues for context
   - If empty, scan everything with defaults
 
 Examples:
@@ -27,7 +27,6 @@ Examples:
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 ```
 
 Parse `$ARGUMENTS` for `focus`, `limit` (default 10), and `include-closed` flag.
@@ -171,7 +170,7 @@ If `focus=AREA` is set, filter to only show items related to that area. Match ag
 
 ### 3. Present Work Queue
 
-Output the primary summary table, then detail sections for each source.
+Output the primary summary table, then detail sections for each source. Cap each detail section to the top `limit` items (default 10) by priority — the queries fetch a wide net so categorization is accurate, but only the most relevant `limit` rows per source are shown. Note any truncation (e.g. "showing top 10 of 23").
 
 #### Primary Output — Work Queue Table
 
@@ -334,4 +333,4 @@ Run `/project-audit` for a comprehensive multi-agent analysis with detailed reco
 6. **Respect blocked/assigned** — Show blocked and assigned items for context but clearly separate them from the actionable queue. Never recommend working on a blocked or assigned item.
 7. **Composable output** — The "Recommended Next Action" section should include copy-pasteable commands (e.g., `/autonomous-dev-flow #12 #18 #25`) so the user can immediately act on the findings.
 8. **No file writes** — The fallback audit in Phase 4 outputs to the conversation only. Unlike `/project-audit`, it does NOT write report files or create a `docs/` directory.
-<!-- skill-templates: start-working 59a26f3 2026-02-26 -->
+<!-- skill-templates: start-working 5df829a 2026-06-12 -->


### PR DESCRIPTION
Re-ports the two skills from the registry after skill-templates#100 fixed the template nits Copilot flagged on #169.

## Changes (both files now stamped `5df829a`)
- `start-working.md` — drop unused `DEFAULT_BRANCH`; `limit` now caps displayed items per source (section 3); drop "(last 7 days)" from `include-closed`.
- `autonomous-dev-flow.md` — drop unused `REPO` setup var.

## Verification
- Both pass `skill-lint.sh` against the updated `registry.json` (stamp ok, guards intact — autonomous-dev-flow's unattended-merge-gate / no-auto-merge / merge-report-entry preserved).

Upstream: blamechris/skill-templates#100 (merged). Closes the repo-relay side of skill-templates#99.